### PR TITLE
Allow higher TYPO3 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "version": "4.0.0",
     "license": "GPL-3.0",
     "require": {
-        "php": ">=7.0.0"
+        "php": ">=7.0.0",
+        "typo3/cms-core": "^9.5 || ^10.4 || ^11.1"
     },
     "keywords": [
         "TYPO3",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '4.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-11.1.99',
+            'typo3' => '9.5.0-11.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
You don't want to release a new version each time a new TYPO3 major version is released