### PR TITLE
Added extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,11 @@
             "email": "info@simon-koehler.com"
         }
     ],
+   	"extra": {
+		"typo3/cms": {
+			"extension-key": "slug"
+		}
+	},
     "autoload": {
         "psr-4": {
             "SIMONKOEHLER\\Slug\\": "Classes"


### PR DESCRIPTION
```Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)```